### PR TITLE
Fix a couple of bindings.

### DIFF
--- a/lib/sodium.ml
+++ b/lib/sodium.ml
@@ -949,5 +949,5 @@ module Generichash = struct
   module Bigbytes = Make(Storage.Bigbytes)
 end
 
-let () =
+let initialized =
   C.init ()

--- a/lib/sodium.mli
+++ b/lib/sodium.mli
@@ -717,3 +717,5 @@ module Generichash : sig
   module Bytes : S with type storage = Bytes.t
   module Bigbytes : S with type storage = bigbytes
 end
+
+val initialized : int

--- a/lib_gen/sodium_bindings.ml
+++ b/lib_gen/sodium_bindings.ml
@@ -23,9 +23,9 @@ module Type = Sodium_types.C(Sodium_types_detected)
 module C(F: Cstubs.FOREIGN) = struct
   let prefix = "sodium"
 
-  let init    = F.foreign (prefix^"_init")    (void @-> returning void)
+  let init    = F.foreign (prefix^"_init")    (void @-> returning int)
   let memzero = F.foreign (prefix^"_memzero") (ocaml_bytes @-> size_t @-> returning void)
-  let memcmp  = F.foreign (prefix^"_memcmp")  (ocaml_bytes @-> ocaml_bytes @-> size_t @-> returning void)
+  let memcmp  = F.foreign (prefix^"_memcmp")  (ocaml_bytes @-> ocaml_bytes @-> size_t @-> returning int)
 
   module Verify = struct
     let verify_type = ocaml_bytes @-> ocaml_bytes @-> returning int


### PR DESCRIPTION
sodium_init and sodium_memcmp both return int.
ocaml-sodium was ignoring those return values, but this is
no longer possible with the -Werror C flag, since recent
versions of libsodium warn about those discarded return values.