### PR TITLE
Use bool for Sodium.initialized.

### DIFF
--- a/lib/sodium.ml
+++ b/lib/sodium.ml
@@ -949,5 +949,8 @@ module Generichash = struct
   module Bigbytes = Make(Storage.Bigbytes)
 end
 
-let initialized =
-  C.init ()
+let initialized = match C.init () with
+  0 -> true
+  | 1 -> true
+  | -1 -> false
+  | _ -> assert false

--- a/lib/sodium.mli
+++ b/lib/sodium.mli
@@ -718,4 +718,4 @@ module Generichash : sig
   module Bigbytes : S with type storage = bigbytes
 end
 
-val initialized : int
+val initialized : bool


### PR DESCRIPTION
Actually C.init() could return 3 values, but we just care
that the library was initialized, so we can collapse that
down to two: true or false.
We use the assert false construct to catch any unexpected
values from C.
