### PR TITLE
install sodium.cmx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: _build/lib_test/nacl_runner
 install:
 	ocamlfind install sodium lib/META \
 		$(addprefix _build/lib/,sodium.mli sodium.cmi sodium.cmti \
-					sodium.cma sodium.cmxa sodium.cmxs \
+					sodium.cma sodium.cmx sodium.cmxa sodium.cmxs \
 		                        sodium$(EXT_LIB) \
 					dllsodium_stubs$(EXT_DLL) \
 					libsodium_stubs$(EXT_LIB))


### PR DESCRIPTION
This is needed to remove a warning on OCaml 4.03+