### PR TITLE
Add key derivation / password hashing primitives.

### DIFF
--- a/lib/sodium_storage.ml
+++ b/lib/sodium_storage.ml
@@ -1,6 +1,4 @@
 open Ctypes
-open Unsigned
-open PosixTypes
 
 type bigbytes =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
@@ -16,8 +14,8 @@ module type S = sig
   val blit       : t -> int -> t -> int -> int -> unit
   val sub        : t -> int -> int -> t
   val length     : t -> int
-  val len_size_t : t -> size_t
-  val len_ullong : t -> ullong
+  val len_size_t : t -> PosixTypes.size_t
+  val len_ullong : t -> Unsigned.ullong
   val to_ptr     : t -> ctype
   val to_bytes   : t -> Bytes.t
   val of_bytes   : Bytes.t -> t
@@ -67,6 +65,7 @@ module Bytes = struct
   let len_ullong byt = Unsigned.ULLong.of_int (Bytes.length byt)
   let to_ptr     byt = ocaml_bytes_start byt
   let zero       byt pos len = Bytes.fill byt pos len '\x00'
+
   let to_bytes   byt = Bytes.copy byt
   let of_bytes   byt = Bytes.copy byt
   let sub            = Bytes.sub

--- a/lib_gen/sodium_bindgen.ml
+++ b/lib_gen/sodium_bindgen.ml
@@ -7,6 +7,7 @@ end
 
 module Bind(F: Cstubs.FOREIGN) = struct
   include Sodium_bindings.C(F)
+  module Sodium' = BindStorage(Make)
   module Random' = BindStorage(Random.Make)
   module Box' = BindStorage(Box.Make)
   module Sign' = BindStorage(Sign.Make)

--- a/lib_gen/sodium_bindgen.ml
+++ b/lib_gen/sodium_bindgen.ml
@@ -10,6 +10,7 @@ module Bind(F: Cstubs.FOREIGN) = struct
   module Random' = BindStorage(Random.Make)
   module Box' = BindStorage(Box.Make)
   module Sign' = BindStorage(Sign.Make)
+  module Password_hash' = BindStorage(Password_hash.Make)
   module Secret_box' = BindStorage(Secret_box.Make)
   module Stream' = BindStorage(Stream.Make)
   module Hash' = BindStorage(Hash.Make)

--- a/lib_gen/sodium_bindings.ml
+++ b/lib_gen/sodium_bindings.ml
@@ -141,6 +141,56 @@ module C(F: Cstubs.FOREIGN) = struct
                                     (ocaml_bytes @-> ocaml_bytes @-> returning int))
   end
 
+  module Password_hash = struct
+    let primitive = "argon2i"
+    let prefix    = "crypto_pwhash_"^primitive
+
+    let sz_query_type   = F.(void @-> returning size_t)
+    let saltbytes       = F.foreign (prefix^"_saltbytes") sz_query_type
+    let strbytes        = F.foreign (prefix^"_strbytes") sz_query_type
+
+    let query_memlimit name =
+      F.foreign (prefix^"_memlimit_" ^ name) F.(void @-> returning size_t)
+
+    let memlimit_interactive = query_memlimit "interactive"
+    let memlimit_moderate = query_memlimit "moderate"
+    let memlimit_sensitive = query_memlimit "sensitive"
+
+    let query_opslimit name =
+      F.foreign (prefix^"_opslimit_" ^ name) F.(void @-> returning int)
+
+    let opslimit_interactive = query_opslimit "interactive"
+    let opslimit_moderate = query_opslimit "moderate"
+    let opslimit_sensitive = query_opslimit "sensitive"
+
+
+    let alg = F.foreign (prefix^"_alg_argon2i13")  F.(void @-> returning int)
+
+    module Make(T: Sodium_storage.S) = struct
+
+      let hash = F.foreign (prefix^"_str")
+          F.(T.ctype @-> (* hash *)
+             ocaml_bytes @-> ullong @-> (* passwd, passwdlen *)
+             ullong @-> size_t @-> (* opslimit, memlimit *)
+             returning int)
+
+      let verify = F.foreign (prefix^"_str_verify")
+          F.(T.ctype @-> (* hash *)
+             ocaml_bytes @-> ullong @-> (* passwd, passwdlen *)
+             returning int)
+
+    end
+
+    let derive = F.foreign prefix
+        F.(ocaml_bytes @-> ullong @-> (* out, outlen *)
+           ocaml_bytes @-> ullong @-> (* passwd, passwdlen *)
+           ocaml_bytes @-> (* salt *)
+           ullong @-> size_t @-> (* opslimit, memlimit *)
+           int @-> (* alg *)
+           returning int)
+
+  end
+
   module Secret_box = struct
     let primitive = "xsalsa20poly1305"
     let prefix    = "crypto_secretbox_"^primitive

--- a/lib_gen/sodium_bindings.ml
+++ b/lib_gen/sodium_bindings.ml
@@ -24,8 +24,12 @@ module C(F: Cstubs.FOREIGN) = struct
   let prefix = "sodium"
 
   let init    = F.(foreign (prefix^"_init")    (void @-> returning int))
-  let memzero = F.(foreign (prefix^"_memzero") (ocaml_bytes @-> size_t @-> returning void))
   let memcmp  = F.(foreign (prefix^"_memcmp")  (ocaml_bytes @-> ocaml_bytes @-> size_t @-> returning int))
+
+  module Make(T: Sodium_storage.S) = struct
+    let memzero =
+      F.(foreign (prefix^"_memzero") (T.ctype @-> size_t @-> returning void))
+  end
 
   module Verify = struct
     let verify_type = F.(ocaml_bytes @-> ocaml_bytes @-> returning int)
@@ -150,19 +154,18 @@ module C(F: Cstubs.FOREIGN) = struct
     let strbytes        = F.foreign (prefix^"_strbytes") sz_query_type
 
     let query_memlimit name =
-      F.foreign (prefix^"_memlimit_" ^ name) F.(void @-> returning size_t)
+      F.foreign (prefix^"_memlimit_"^name) sz_query_type
 
     let memlimit_interactive = query_memlimit "interactive"
     let memlimit_moderate = query_memlimit "moderate"
     let memlimit_sensitive = query_memlimit "sensitive"
 
     let query_opslimit name =
-      F.foreign (prefix^"_opslimit_" ^ name) F.(void @-> returning int)
+      F.foreign (prefix^"_opslimit_"^name) F.(void @-> returning int)
 
     let opslimit_interactive = query_opslimit "interactive"
     let opslimit_moderate = query_opslimit "moderate"
     let opslimit_sensitive = query_opslimit "sensitive"
-
 
     let alg = F.foreign (prefix^"_alg_argon2i13")  F.(void @-> returning int)
 
@@ -178,7 +181,6 @@ module C(F: Cstubs.FOREIGN) = struct
           F.(T.ctype @-> (* hash *)
              ocaml_bytes @-> ullong @-> (* passwd, passwdlen *)
              returning int)
-
     end
 
     let derive = F.foreign prefix
@@ -188,7 +190,6 @@ module C(F: Cstubs.FOREIGN) = struct
            ullong @-> size_t @-> (* opslimit, memlimit *)
            int @-> (* alg *)
            returning int)
-
   end
 
   module Secret_box = struct

--- a/lib_test/test_password_hash.ml
+++ b/lib_test/test_password_hash.ml
@@ -1,0 +1,56 @@
+(*
+ * Copyright (c) 2014 Peter Zotov <whitequark@whitequark.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open OUnit2
+open Sodium
+
+let password str =
+  Password_hash.Bytes.wipe_to_password (Bytes.of_string str)
+
+let test_derive_secret_box_keys ctxt =
+  let pw  = password "Correct Horse Battery Staple" in
+  let pw' = password "Correct Battery Horse Staple" in
+  let n = Password_hash.random_nonce () in
+  let n' = Password_hash.random_nonce () in
+  let sk = Secret_box.derive_key pw (Password_hash.interactive, n) in
+  let sk2 = Secret_box.derive_key pw (Password_hash.interactive, n) in
+  let sk' = Secret_box.derive_key pw (Password_hash.interactive, n') in
+  let sk'2 = Secret_box.derive_key pw (Password_hash.interactive, n') in
+  let sk'' = Secret_box.derive_key pw (Password_hash.moderate, n) in
+  let sk''2 = Secret_box.derive_key pw (Password_hash.moderate, n) in
+  let sk''' = Secret_box.derive_key pw' (Password_hash.interactive, n) in
+  let sk'''2 = Secret_box.derive_key pw' (Password_hash.interactive, n) in
+  assert_bool "=" (Secret_box.equal_keys sk sk);
+  assert_bool "=" (Secret_box.equal_keys sk sk2);
+  assert_bool "=" (Secret_box.equal_keys sk' sk'2);
+  assert_bool "=" (Secret_box.equal_keys sk'' sk''2);
+  assert_bool "=" (Secret_box.equal_keys sk''' sk'''2);
+  assert_bool "<>" (not (Secret_box.equal_keys sk sk'));
+  assert_bool "<>" (not (Secret_box.equal_keys sk sk''));
+  assert_bool "<>" (not (Secret_box.equal_keys sk sk'''))
+
+let test_password_hashing ctxt =
+  let pw  = password "Correct Horse Battery Staple" in
+  let pw' = password "Correct Battery Horse Staple" in
+  let h = Password_hash.Bytes.hash_password pw Password_hash.interactive in
+  assert_bool "=" (Password_hash.Bytes.verify_password_hash pw h);
+  assert_bool "<>" (not (Password_hash.Bytes.verify_password_hash pw' h))
+
+let suite = "Password_hash" >::: [
+    "test_password_hashing"             >:: test_password_hashing;
+    "test_derive_secret_box_keys"       >:: test_derive_secret_box_keys;
+  ]

--- a/lib_test/test_password_hash.ml
+++ b/lib_test/test_password_hash.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2014 Peter Zotov <whitequark@whitequark.org>
+ * Copyright (c) 2016 Benjamin Canou <benjamin@ocamlpro.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -24,16 +24,18 @@ let password str =
 let test_derive_secret_box_keys ctxt =
   let pw  = password "Correct Horse Battery Staple" in
   let pw' = password "Correct Battery Horse Staple" in
-  let n = Password_hash.random_nonce () in
-  let n' = Password_hash.random_nonce () in
-  let sk = Secret_box.derive_key pw (Password_hash.interactive, n) in
-  let sk2 = Secret_box.derive_key pw (Password_hash.interactive, n) in
-  let sk' = Secret_box.derive_key pw (Password_hash.interactive, n') in
-  let sk'2 = Secret_box.derive_key pw (Password_hash.interactive, n') in
-  let sk'' = Secret_box.derive_key pw (Password_hash.moderate, n) in
-  let sk''2 = Secret_box.derive_key pw (Password_hash.moderate, n) in
-  let sk''' = Secret_box.derive_key pw' (Password_hash.interactive, n) in
-  let sk'''2 = Secret_box.derive_key pw' (Password_hash.interactive, n) in
+  let n = Password_hash.random_salt () in
+  let n' = Password_hash.random_salt () in
+  let derive_interactive = Secret_box.derive_key Password_hash.interactive in
+  let derive_moderate = Secret_box.derive_key Password_hash.moderate in
+  let sk = derive_interactive pw n in
+  let sk2 = derive_interactive pw n in
+  let sk' = derive_interactive pw n' in
+  let sk'2 = derive_interactive pw n' in
+  let sk'' = derive_moderate pw n in
+  let sk''2 = derive_moderate pw n in
+  let sk''' = derive_interactive pw' n in
+  let sk'''2 = derive_interactive pw' n in
   assert_bool "=" (Secret_box.equal_keys sk sk);
   assert_bool "=" (Secret_box.equal_keys sk sk2);
   assert_bool "=" (Secret_box.equal_keys sk' sk'2);
@@ -46,9 +48,9 @@ let test_derive_secret_box_keys ctxt =
 let test_password_hashing ctxt =
   let pw  = password "Correct Horse Battery Staple" in
   let pw' = password "Correct Battery Horse Staple" in
-  let h = Password_hash.Bytes.hash_password pw Password_hash.interactive in
-  assert_bool "=" (Password_hash.Bytes.verify_password_hash pw h);
-  assert_bool "<>" (not (Password_hash.Bytes.verify_password_hash pw' h))
+  let h = Password_hash.Bytes.hash_password Password_hash.interactive pw in
+  assert_bool "=" (Password_hash.Bytes.verify_password_hash h pw);
+  assert_bool "<>" (not (Password_hash.Bytes.verify_password_hash h pw'))
 
 let suite = "Password_hash" >::: [
     "test_password_hashing"             >:: test_password_hashing;

--- a/lib_test/test_sodium.ml
+++ b/lib_test/test_sodium.ml
@@ -22,6 +22,7 @@ let suite = "Sodium" >::: [
     Test_box.suite;
     Test_scalar_mult.suite;
     Test_sign.suite;
+    Test_password_hash.suite;
     Test_secret_box.suite;
     Test_stream.suite;
     Test_auth.suite;

--- a/opam
+++ b/opam
@@ -5,6 +5,7 @@ maintainer: "sheets@alum.mit.edu"
 authors: [
   "David Sheets <sheets@alum.mit.edu>"
   "Peter Zotov <whitequark@whitequark.org>"
+  "Benjamin Canou <benjamin@ocamlpro.com>"
 ]
 homepage: "https://github.com/dsheets/ocaml-sodium/"
 bug-reports: "https://github.com/dsheets/ocaml-sodium/issues/"


### PR DESCRIPTION
Binds the password hashing Argon2i primitives.
Adds key derivation from human passwords for the various secret key instances.

Cf. https://download.libsodium.org/doc/password_hashing/the_argon2i_function.html