### PR TITLE
Fail descriptively during initialization

### DIFF
--- a/lib/sodium.ml
+++ b/lib/sodium.ml
@@ -949,5 +949,8 @@ module Generichash = struct
   module Bigbytes = Make(Storage.Bigbytes)
 end
 
-let initialized =
-  C.init ()
+let initialized = match C.init () with
+  0 -> true
+  | 1 -> true
+  | -1 -> false
+  | _ -> assert false

--- a/lib/sodium.ml
+++ b/lib/sodium.ml
@@ -950,7 +950,6 @@ module Generichash = struct
 end
 
 let initialized = match C.init () with
-  0 -> true
-  | 1 -> true
+  | 0 | 1 -> true
   | -1 -> false
-  | _ -> assert false
+  | _ -> failwith "libsodium initialization failed unexpectedly"

--- a/lib/sodium.mli
+++ b/lib/sodium.mli
@@ -718,4 +718,4 @@ module Generichash : sig
   module Bigbytes : S with type storage = bigbytes
 end
 
-val initialized : int
+val initialized : bool


### PR DESCRIPTION
Based on @CMB's #31, this fails descriptively during initialization if an unexpected value is returned. Because sodium initialization occurs at module load time, an unexpected initialization will prohibit the application from starting.